### PR TITLE
add git-config as dependency instead of devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "chalk": "^2.1.0",
     "generator-license": "^5.1.0",
+    "git-config": "0.0.7",
     "inquirer-npm-name": "^2.0.0",
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
@@ -51,7 +52,6 @@
     "cross-env": "^5.0.5",
     "eslint": "^4.0.0",
     "eslint-config-xo-space": "^0.16.0",
-    "git-config": "0.0.7",
     "mocha": "^3.5.0",
     "mockery": "^2.1.0",
     "nyc": "^11.2.0",


### PR DESCRIPTION
Running `yo postcss-plugin` throws an error "Error: Cannot find module 'git-config'".
